### PR TITLE
Update the specification of OpenFunction Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OpenFunction Functions Framework is designed to provide users of FaaS with a sui
 ### Runtime
 
 - Knative
-- KEDA + Dapr
+- OpenFuncAsync
 
 ### Function Type
 
@@ -37,4 +37,3 @@ OpenFunction Functions Framework is designed to provide users of FaaS with a sui
 ## Contributing
 
 You can get help on developing OpenFunction Functions Framework by visiting [CONTRIBUTING](CONTRIBUTING.md) .
-

--- a/docs/OpenFunction-context-specs.md
+++ b/docs/OpenFunction-context-specs.md
@@ -12,78 +12,103 @@ OpenFunction/functions-framework-go -> ff-go
 
 ## Context
 
+Example:
+
+```json
+{
+  "name": "function",
+  "version": "v1",
+  "requestID": "a0f2ad8d-5062-4812-91e9-95416489fb01",
+  "port": "50002",
+  "input": {},
+  "outputs": {},
+  "runtime": "OpenFuncAsync",
+  "state": ""
+}
+```
+
+Specification:
+
 | Key        | Type            | Description                                               | Scope                                                        | example                                |
 | ---------- | --------------- | --------------------------------------------------------- | ------------------------------------------------------------ | -------------------------------------- |
-| name       | string, require | Function name                                             | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "myfunction", "hello-func"             |
-| version    | string, require | Function version                                          | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "v1", "v2"                             |
-| request_id | string          | Request ID, uuid format                                   | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "a0f2ad8d-5062-4812-91e9-95416489fb01" |
-| protocol   | enum, require   | Function serving kind, see [Protocol](#protocol)          | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "gRPC", "HTTP"                         |
-| port       | string, require | Function serving port                                     | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "8080", "50001"                        |
-| input      | object          | Function input from bindings data, see [Input](#input)    | [ff-go](https://github.com/OpenFunction/functions-framework-go) |                                        |
-| outputs    | object          | Function output to bindings data, see [Outputs](#outputs) | [ff-go](https://github.com/OpenFunction/functions-framework-go) |                                        |
-| runtime    | enum, require   | Function serving runtime, see [Runtime](#runtime)         | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "Knative", "Dapr"                      |
-| state      | string          | Used to store the states of the function in operation     |                                                              |                                        |
-
-### Protocol 
-
-We currently support `HTTP` and `gRPC` protocol modes.
-
-| Value | Description                         | Scope                                                        |
-| ----- | ----------------------------------- | ------------------------------------------------------------ |
-| HTTP  | Serving function with HTTP protocol | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
-| gRPC  | Serving function with gRPC protocol | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
-
-<div align="right">
-    <b><a href="#context">↥ back to Context</a></b>
-</div>
+| name       | string, require | Function name.                                            | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "myfunction", "hello-func"             |
+| version    | string, require | Function version.                                         | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "v1", "v2"                             |
+| requestID | string          | Request ID, uuid format.                                  | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "a0f2ad8d-5062-4812-91e9-95416489fb01" |
+| port       | string, require | Function serving port.                                    | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "50001"                        |
+| input      | object          | Function input from bindings data, see [Input](#input). Empty means no input. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |                                        |
+| outputs    | map        | Function output to bindings data. <br />A map of Output objects. The key is the name of output. When using OpenFuncAsync as runtime, this name needs to be consistent with the corresponding Dapr component resource name. Refer to [this docs](https://docs.dapr.io/concepts/components-concept/) to learn about Dapr components. <br />The value is output object, see [Output](#output). Empty means no output. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |                                        |
+| runtime    | enum, require   | Function serving runtime, see [Runtime](#runtime).       | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "Knative", "OpenFuncAsync"       |
+| state      | string          | Used to store the states of the function in operation.    |                                                              |                                        |
 
 ### Input
 
+Example:
+
+```json
+{
+  "name": "my_input",
+  "uri": "my_topic",
+  "params": {
+    "type": "pubsub"
+  }
+}
+```
+
+Specification:
+
 | Key        | Type   | Description                                                  | Scope                                           | example                                |
 | ---------- | ------ | ------------------------------------------------------------ | -------------------------------------- | -------------------------------------- |
-| name       | string | Input name. When using Dapr as runtime, this name needs to be consistent with the corresponding Dapr component resource name. Refer to [this docs](https://docs.dapr.io/concepts/components-concept/) to learn about Dapr components. | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "demo-kafka", "cron-job" |
-| enable | bool, require | Switch of input                              | [ff-go](https://github.com/OpenFunction/functions-framework-go) | true, false                |
-| pattern | string | Input serving listening path. For HTTP functions, it can be set to "/somepath" while "somepath" for gRPC functions. This indicates the destination of the input data. | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "echo", "/echo" |
-| in_type | enum   | Input type. Effective only when using Dapr as runtime. See [InType](#intype) | [ff-go](https://github.com/OpenFunction/functions-framework-go) |                          |
+| name       | string | Input name. When using OpenFuncAsync as runtime, this name needs to be consistent with the corresponding Dapr component resource name. Refer to [this docs](https://docs.dapr.io/concepts/components-concept/) to learn about Dapr components. | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "demo-kafka", "cron-job" |
+| uri | string | Input serving listening path. This indicates the destination of the input data. | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "echo" |
+| params | map | Input params. When using OpenFuncAsync as runtime, you need to set the `type` (refer to [Input Type](#input-type)) parameter. | [ff-go](https://github.com/OpenFunction/functions-framework-go) | {"type": "pubsub"} |
 
-#### InType
+#### Input Type
 
-Effective only when using Dapr as runtime. 
+Effective only when using OpenFuncAsync as runtime. 
 
 | Value    | Description                                                  | Scope                                                        |
 | -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | bindings | Indicates that the input is the Dapr bindings component. Refer to [Bindings API reference](https://docs.dapr.io/reference/api/bindings_api/) to learn more about Dapr bindings components. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
-| pubsub   | Indicates that the input is the Dapr pubsub component. Refer to [Pub/sub API reference](https://docs.dapr.io/reference/api/pubsub_api/) to learn more about Dapr bindings components. <br />:heavy_exclamation_mark:Note that when using pubsub as input, the name of pubsub's topic should be assigned to the input's pattern. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
-| invoke   | Indicates that the input is the Dapr service invocation component. Refer to [Service invocation API reference](https://docs.dapr.io/reference/api/service_invocation_api/) to learn more about Dapr bindings components.<br />:heavy_exclamation_mark:Note that when using invoke as input, the name of invoke method should be assigned to the input's pattern. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
+| pubsub   | Indicates that the input is the Dapr pubsub component. Refer to [Pub/sub API reference](https://docs.dapr.io/reference/api/pubsub_api/) to learn more about Dapr bindings components. <br />:heavy_exclamation_mark:Note that when using pubsub as input, the name of pubsub's topic should be assigned to the input's uri. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
+| invoke   | Indicates that the input is the Dapr service invocation component. Refer to [Service invocation API reference](https://docs.dapr.io/reference/api/service_invocation_api/) to learn more about Dapr bindings components.<br />:heavy_exclamation_mark:Note that when using invoke as input, the name of invoke method should be assigned to the input's uri. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
 
 <div align="right">
     <b><a href="#context">↥ back to Context</a></b>
 </div>
-
 ### Outputs
 
-| Key            | Type          | Description                                                  | Scope                                                        | example     |
-| -------------- | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ----------- |
-| enable         | bool, require | Switch of outputs                                            | [ff-go](https://github.com/OpenFunction/functions-framework-go) | true, false |
-| output_objects | map           | A map of Output objects. <br />The key is the name of output. When using Dapr as runtime, this name needs to be consistent with the corresponding Dapr component resource name. Refer to [this docs](https://docs.dapr.io/concepts/components-concept/) to learn about Dapr components. <br />The value is output object, see [Output](#output) | [ff-go](https://github.com/OpenFunction/functions-framework-go) |             |
+Examples:
+
+```json
+{
+  "my_output": {
+    "uri": "print",
+    "params": {
+      "method": "post",
+      "type": "invoke"
+    }
+  }
+}
+```
+
+Specification:
 
 #### Output
 
-| Key      | Type   | Description                                                  | Scope                                                        | example                                     |
-| -------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------- |
-| pattern  | string | Output serving listening path. For HTTP functions, it can be set to "/somepath" while "somepath" for gRPC functions. This indicates the destination of the out data. | [ff-go](https://github.com/OpenFunction/functions-framework-go) | true, false                                 |
-| out_type | enum   | Output type. Effective only when using Dapr as runtime. See [OutType](#outtype) | [ff-go](https://github.com/OpenFunction/functions-framework-go) |                                             |
-| params   | map    | Used to store parameters when using output.                  | [ff-go](https://github.com/OpenFunction/functions-framework-go) | {"method": "post"}, {"operation": "create"} |
+| Key    | Type   | Description                                                  | Scope                                                        | example                                     |
+| ------ | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------- |
+| uri    | string | Output serving listening path. This indicates the destination of the out data. | [ff-go](https://github.com/OpenFunction/functions-framework-go) | "echo"                                      |
+| params | map    | When using OpenFuncAsync as runtime, you need to set the `type` (refer to [Output Type](#output-type)) parameter. <br />You also need to set other relevant parameters according to [Dapr's docs](https://docs.dapr.io/reference/api/). | [ff-go](https://github.com/OpenFunction/functions-framework-go) | {"method": "post"}, {"operation": "create"} |
 
-##### OutType
+##### Output Type
 
-Effective only when using Dapr as runtime. 
+Effective only when using OpenFuncAsync as runtime. 
 
 | Value    | Description                                                  | Scope                                                        |
 | -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | bindings | Indicates that the output is the Dapr bindings component. Refer to [Bindings API reference](https://docs.dapr.io/reference/api/bindings_api/) to learn more about Dapr bindings components. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
-| pubsub   | Indicates that the output is the Dapr pubsub component. Refer to [Pub/sub API reference](https://docs.dapr.io/reference/api/pubsub_api/) to learn more about Dapr bindings components. <br />:heavy_exclamation_mark:Note that when using pubsub as output, the name of pubsub's topic should be assigned to the output's pattern. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
-| invoke   | Indicates that the output is the Dapr service invocation component. Refer to [Service invocation API reference](https://docs.dapr.io/reference/api/service_invocation_api/) to learn more about Dapr bindings components.<br />:heavy_exclamation_mark:Note that when using invoke as output, the name of invoke method should be assigned to the output's pattern. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
+| pubsub   | Indicates that the output is the Dapr pubsub component. Refer to [Pub/sub API reference](https://docs.dapr.io/reference/api/pubsub_api/) to learn more about Dapr bindings components. <br />:heavy_exclamation_mark:Note that when using pubsub as output, the name of pubsub's topic should be assigned to the output's uri. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
+| invoke   | Indicates that the output is the Dapr service invocation component. Refer to [Service invocation API reference](https://docs.dapr.io/reference/api/service_invocation_api/) to learn more about Dapr bindings components.<br />:heavy_exclamation_mark:Note that when using invoke as output, the name of invoke method should be assigned to the output's uri. | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
 
 <div align="right">
     <b><a href="#context">↥ back to Context</a></b>
@@ -91,12 +116,12 @@ Effective only when using Dapr as runtime.
 
 ### Runtime
 
-We currently support `Knative` and `Dapr` serving runtime.
+We currently support `Knative` and `OpenFuncAsync` serving runtime.
 
-| Value   | Description                           | Scope                                                        |
-| ------- | ------------------------------------- | ------------------------------------------------------------ |
-| Knative | Serving function with Knative runtime | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
-| Dapr    | Serving function with Dapr runtime    | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
+| Value         | Description                                                  | Scope                                                        |
+| ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Knative       | Serving function with Knative runtime (based on Knative).    | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
+| OpenFuncAsync | Serving function with OpenFuncAsync runtime (based on KEDA+Dapr). | [ff-go](https://github.com/OpenFunction/functions-framework-go) |
 
 <div align="right">
     <b><a href="#context">↥ back to Context</a></b>


### PR DESCRIPTION
1. Remove the `input` and `output` switch
2. Rename `Dapr` to `OpenFuncAsync`
3. Remove the `protocol`, default use `grpc`
4. Rename `pattern` to `uri`
5. Put the `inType`, `outType` into `params` and rename them to `type`

Signed-off-by: laminar <fangtian@kubesphere.io>